### PR TITLE
fix: browserouter extract structure has been changed

### DIFF
--- a/bucket/browserouter.json
+++ b/bucket/browserouter.json
@@ -3,13 +3,12 @@
     "version": "0.14.0",
     "homepage": "https://github.com/slater1/BrowseRouter",
     "license": "MIT",
-    "url": "https://github.com/slater1/BrowseRouter/releases/download/0.14.0/BrowseRouter.0.14.0.zip",
+    "url": "https://github.com/slater1/BrowseRouter/releases/download/0.14.0/BrowseRouter-win-x64.zip",
     "hash": "",
     "extract_dir": "BrowseRouter 0.14.0",
     "bin": "BrowseRouter.exe",
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/slater1/BrowseRouter/releases/download/$version/BrowseRouter.$majorVersion.$minorVersion.$patchVersion.zip",
-        "extract_dir": "BrowseRouter $majorVersion.$minorVersion.$patchVersion"
+        "url": "https://github.com/slater1/BrowseRouter/releases/download/$version/BrowseRouter-win-x64.zip"
     }
 }


### PR DESCRIPTION
fix https://github.com/guitarrapc/scoop-bucket/issues/5

## tl;dr;

* Link changed to `https://github.com/nref/BrowseRouter/releases/download/0.14.0/BrowseRouter-win-x64.zip`
* ExtractDir is no longer needed.